### PR TITLE
[OBSINTA-291] Updating Grafana dashboard to display top n underutilized namespaces 

### DIFF
--- a/data-assets/acm_right_sizing_grafana_dashboard.yaml
+++ b/data-assets/acm_right_sizing_grafana_dashboard.yaml
@@ -31,7 +31,7 @@ data:
       "gnetId": null,
       "graphTooltip": 0,
       "id": 15,
-      "iteration": 1727976284238,
+      "iteration": 1728059156670,
       "links": [],
       "panels": [
         {
@@ -173,7 +173,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "topk(${top_n},\nsum by (namespace) (acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\"})\n/\nsum by (namespace) (acm_rs:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\"})\n)",
+              "expr": "topk(20,\nsum by (namespace) (acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\"})\n/\nsum by (namespace) (acm_rs:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\"})\n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -924,7 +924,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "topk(${top_n},\nsum by (namespace) (acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\"})\n/\nsum by (namespace) (acm_rs:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\"})\n)",
+              "expr": "topk(20,\nsum by (namespace) (acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\"})\n/\nsum by (namespace) (acm_rs:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\"})\n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -1528,7 +1528,7 @@ data:
           "type": "table"
         }
       ],
-      "refresh": "",
+      "refresh": false,
       "schemaVersion": 30,
       "style": "dark",
       "tags": [],
@@ -1557,18 +1557,14 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": false,
+              "selected": true,
               "text": "ac-test-man-1",
               "value": "ac-test-man-1"
             },
             "datasource": "${datasource}",
             "definition": "label_values(acm_rs:cluster:cpu_request,cluster)",
             "description": null,
-            "error": {
-              "data": {
-                "message": "Unexpected error"
-              }
-            },
+            "error": null,
             "hide": 0,
             "includeAll": false,
             "label": "Cluster",
@@ -1615,7 +1611,7 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": false,
+              "selected": true,
               "text": "5d",
               "value": "5d"
             },
@@ -1667,51 +1663,16 @@ data:
             "queryValue": "",
             "skipUrlSync": false,
             "type": "custom"
-          },
-          {
-            "allValue": null,
-            "current": {
-              "selected": false,
-              "text": "5",
-              "value": "5"
-            },
-            "description": null,
-            "error": null,
-            "hide": 0,
-            "includeAll": false,
-            "label": null,
-            "multi": false,
-            "name": "top_n",
-            "options": [
-              {
-                "selected": true,
-                "text": "5",
-                "value": "5"
-              },
-              {
-                "selected": false,
-                "text": "10",
-                "value": "10"
-              },
-              {
-                "selected": false,
-                "text": "20",
-                "value": "20"
-              }
-            ],
-            "query": "5, 10, 20",
-            "skipUrlSync": false,
-            "type": "custom"
           }
         ]
       },
       "time": {
-        "from": "now-90d",
+        "from": "now-7d",
         "to": "now"
       },
       "timepicker": {},
       "timezone": "",
       "title": "ACM Right-Sizing Namespace",
       "uid": "bnqQIPySE",
-      "version": 5
+      "version": 2
     }

--- a/data-assets/acm_right_sizing_grafana_dashboard.yaml
+++ b/data-assets/acm_right_sizing_grafana_dashboard.yaml
@@ -30,8 +30,8 @@ data:
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
-      "id": 34,
-      "iteration": 1723026380481,
+      "id": 15,
+      "iteration": 1727976284238,
       "links": [],
       "panels": [
         {
@@ -173,7 +173,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\"}",
+              "expr": "topk(${top_n},\nsum by (namespace) (acm_rs:namespace:cpu_usage{cluster=\"$cluster\", profile=\"$profile\"})\n/\nsum by (namespace) (acm_rs:namespace:cpu_request{cluster=\"$cluster\", profile=\"$profile\"})\n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -185,7 +185,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "CPU Usage",
+          "title": "CPU Usage of Top Underutilized Namespaces",
           "tooltip": {
             "shared": false,
             "sort": 0,
@@ -924,7 +924,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\"}",
+              "expr": "topk(${top_n},\nsum by (namespace) (acm_rs:namespace:memory_usage{cluster=\"$cluster\", profile=\"$profile\"})\n/\nsum by (namespace) (acm_rs:namespace:memory_request{cluster=\"$cluster\", profile=\"$profile\"})\n)",
               "format": "time_series",
               "instant": false,
               "interval": "",
@@ -936,7 +936,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Memory Usage",
+          "title": "Memory Usage for Top Underutilized Namespaces",
           "tooltip": {
             "shared": false,
             "sort": 0,
@@ -1558,13 +1558,17 @@ data:
             "allValue": null,
             "current": {
               "selected": false,
-              "text": "spoke1",
-              "value": "spoke1"
+              "text": "ac-test-man-1",
+              "value": "ac-test-man-1"
             },
             "datasource": "${datasource}",
             "definition": "label_values(acm_rs:cluster:cpu_request,cluster)",
             "description": null,
-            "error": null,
+            "error": {
+              "data": {
+                "message": "Unexpected error"
+              }
+            },
             "hide": 0,
             "includeAll": false,
             "label": "Cluster",
@@ -1611,7 +1615,7 @@ data:
           {
             "allValue": null,
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "5d",
               "value": "5d"
             },
@@ -1663,16 +1667,51 @@ data:
             "queryValue": "",
             "skipUrlSync": false,
             "type": "custom"
+          },
+          {
+            "allValue": null,
+            "current": {
+              "selected": false,
+              "text": "5",
+              "value": "5"
+            },
+            "description": null,
+            "error": null,
+            "hide": 0,
+            "includeAll": false,
+            "label": null,
+            "multi": false,
+            "name": "top_n",
+            "options": [
+              {
+                "selected": true,
+                "text": "5",
+                "value": "5"
+              },
+              {
+                "selected": false,
+                "text": "10",
+                "value": "10"
+              },
+              {
+                "selected": false,
+                "text": "20",
+                "value": "20"
+              }
+            ],
+            "query": "5, 10, 20",
+            "skipUrlSync": false,
+            "type": "custom"
           }
         ]
       },
       "time": {
-        "from": "now-7d",
+        "from": "now-90d",
         "to": "now"
       },
       "timepicker": {},
       "timezone": "",
       "title": "ACM Right-Sizing Namespace",
       "uid": "bnqQIPySE",
-      "version": 6
+      "version": 5
     }


### PR DESCRIPTION
Updating Grafana dashboard to display top n underutilized namespaces in CPU and Memory panels

related issue: https://issues.redhat.com/browse/OBSINTA-291